### PR TITLE
multiple launch_buttons settings + force re-execution

### DIFF
--- a/content/_config.yml
+++ b/content/_config.yml
@@ -26,10 +26,8 @@ repository:
   
 launch_buttons:
   notebook_interface: "jupyterlab"  # or "classic"
-  binderhub_url: "https://binder.conp.cloud" 
-
-launch_buttons:
-  thebe                  : true
+  binderhub_url: "https://binder.conp.cloud"
+  thebe: true
 
 execute:
-  execute_notebooks: 'off'
+  execute_notebooks: 'force'


### PR DESCRIPTION
Last try, maybe your launch button parameters were ignored because you had a second one. And I imagine it takes into account just the last one ?
Also forcing notebook re-execution.